### PR TITLE
Made it work on OS X v10.10

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -44,9 +44,10 @@ except ImportError:
     pass
 
 try:
-    from uptime._posix import _uptime_posix
+    from uptime._posix import _uptime_posix, _uptime_osx
 except ImportError:
     _uptime_posix = lambda: None
+    _uptime_osx = lambda: None
 
 __all__ = ['uptime', 'boottime']
 
@@ -193,8 +194,6 @@ def _uptime_minix():
         return up
     except (IOError, ValueError):
         return None
-
-_uptime_osx = _uptime_bsd
 
 def _uptime_plan9():
     """Returns uptime in seconds or None, on Plan 9."""
@@ -347,7 +346,7 @@ def uptime():
            _uptime_bsd() or _uptime_plan9() or _uptime_linux() or \
            _uptime_windows() or _uptime_solaris() or _uptime_beos() or \
            _uptime_amiga() or _uptime_riscos() or _uptime_posix() or \
-           _uptime_syllable() or _uptime_mac()
+           _uptime_syllable() or _uptime_mac() or _uptime_osx()
 
 def boottime():
     """Returns boot time if remotely possible, or None if not."""

--- a/src/_posix.c
+++ b/src/_posix.c
@@ -2,7 +2,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utmpx.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 #include <sys/time.h>
+
 
 /*
 The reason this exists as a full-blown C extension instead of as a pure-Python
@@ -12,21 +16,61 @@ members. In practice, all of these things vary, and there's no way for us to
 find any of them at runtime from Python.
 */
 
+double _calc_uptime(struct timeval bt) {
+    struct timeval tv;
+    /* Get current time. */
+    if (gettimeofday(&tv, NULL) != 0) {
+        return -1;
+    }
+    
+    /* Subtract boot time from current time. */
+    if (tv.tv_usec < bt.tv_usec) {
+        tv.tv_sec--;
+        tv.tv_usec = 1000000 - bt.tv_usec + tv.tv_usec;
+    } else {
+        tv.tv_usec -= bt.tv_usec;
+    }
+    tv.tv_sec -= bt.tv_sec;
+    
+    return (unsigned)tv.tv_sec + (unsigned)tv.tv_usec / 1000000.0;
+}
+
+#ifdef __APPLE__
+static PyObject*
+_uptime_osx(PyObject *self, PyObject *args)
+{
+    struct timeval bt;
+    size_t len = sizeof(bt);
+    
+    /* Unused arguments. */
+    (void)self;
+    (void)args;
+    
+    /* Get boot time if it's there. */
+    if (sysctlbyname("kern.boottime", &bt, &len, NULL, 0) != 0) {
+        Py_RETURN_NONE;
+    }
+    
+    return Py_BuildValue("d", _calc_uptime(bt));
+}
+#else
+// Other systems might not use sysctl
+static PyObject*
+_uptime_osx(PyObject *self, PyObject *args) {
+    Py_RETURN_NONE
+}
+#endif
+
+
 static PyObject*
 _uptime_posix(PyObject *self, PyObject *args)
 {
     struct utmpx id = {.ut_type = BOOT_TIME}, *res;
-    struct timeval tv, bt;
-    double up;
+    struct timeval bt;
 
     /* Unused arguments. */
     (void)self;
     (void)args;
-
-    /* Get current time. */
-    if (gettimeofday(&tv, NULL) != 0) {
-        Py_RETURN_NONE;
-    }
 
     /* Get boot time if it's there. */
     if ((res = getutxid(&id)) == NULL) {
@@ -36,22 +80,14 @@ _uptime_posix(PyObject *self, PyObject *args)
     memcpy(&bt, &(res->ut_tv), sizeof(struct timeval));
     endutxent();
 
-    /* Subtract boot time from current time. */
-    if (tv.tv_usec < bt.tv_usec) {
-        tv.tv_sec--;
-        tv.tv_usec = 1000000 - bt.tv_usec + tv.tv_usec;
-    } else {
-        tv.tv_usec -= bt.tv_usec;
-    }
-    tv.tv_sec -= bt.tv_sec;
-
-    up = (unsigned)tv.tv_sec + (unsigned)tv.tv_usec / 1000000.0;
-    return Py_BuildValue("d", up);
+    return Py_BuildValue("d", _calc_uptime(bt));
 }
 
 static PyMethodDef _uptime_methods[] = {
     {"_uptime_posix", _uptime_posix, METH_NOARGS,
      "Fallback uptime for POSIX."},
+    {"_uptime_osx", _uptime_osx, METH_NOARGS,
+        "Uptime for OS X"},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
On OS X v10.10 the _uptime_bsd() function failed to calculate the size
of the buffer and returned None