### PR TITLE
The library tries to read /proc/stat under windows. 

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -352,12 +352,13 @@ def boottime():
     """Returns boot time if remotely possible, or None if not."""
     global __boottime
 
+    if __boottime is None and (not sys.platform in ["wince","win32","darwin"]) :
+        _boottime_linux()
+
     if __boottime is None:
         up = uptime()
         if up is None:
             return None
-    if __boottime is None:
-        _boottime_linux()
 
     if datetime is None:
         raise RuntimeError('datetime module required.')


### PR DESCRIPTION
This poses a security problem since anyone can create a file at the root of the disk under Windows 10.

If the file is too big it can cause python to crash.

(Discovered during a software security audit)